### PR TITLE
chore: increase pull request limit and accept major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,5 @@ updates:
     labels:
       - "dependencies"
       - "javascript"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-major"]
     versioning-strategy: increase
+    open-pull-requests-limit: 10


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

#### Changelog

- **Chores**
  - Updated Dependabot settings to allow major version updates for dependencies.
  - Limited the maximum number of open Dependabot pull requests to 10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->